### PR TITLE
feat : setup webhook with ngork/github webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-NODE_ENV=development
+NODE_ENV=production
 LOG_LEVEL=info
 TRUST_PROXY=true

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NODE_ENV=development
 LOG_LEVEL=info
+TRUST_PROXY=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "cors": "^2.8.5",
         "dockerode": "^4.0.7",
+        "dotenv": "^16.1.4",
         "express": "^5.1.0",
         "express-rate-limit": "^7.0.0",
         "get-port": "^7.1.0",
         "helmet": "^6.0.1",
         "pino": "^8.21.0",
-        "pino-http": "^8.4.0",
         "pino-pretty": "^8.1.0"
       },
       "devDependencies": {
@@ -24,7 +24,6 @@
         "@types/express": "^4.17.21",
         "@types/helmet": "^4.0.0",
         "@types/node": "^20.19.11",
-        "@types/pino-http": "^6.0.6",
         "nodemon": "^3.1.10",
         "rimraf": "^5.0.0",
         "tsx": "^4.20.5",
@@ -792,17 +791,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/pino-http": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-6.1.0.tgz",
-      "integrity": "sha512-rjPOSk2yI0714Pi8LdjIhDynXWqOvswmjRiTHj/1TOh1+0R26aKJ8vAVZRc4Ky5dQ5M5Bly1vrV/Klew6lThkA==",
-      "deprecated": "This is a stub types definition. pino-http provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pino-http": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -1318,6 +1306,18 @@
       },
       "engines": {
         "node": ">= 8.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -2439,18 +2439,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/pino-http": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-8.6.1.tgz",
-      "integrity": "sha512-J0hiJgUExtBXP2BjrK4VB305tHXS31sCmWJ9XJo2wPkLHa1NFPuW4V9wjG27PAc2fmBCigiNhQKpvrx+kntBPA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-caller-file": "^2.0.5",
-        "pino": "^8.17.1",
-        "pino-std-serializers": "^6.2.2",
-        "process-warning": "^3.0.0"
       }
     },
     "node_modules/pino-pretty": {

--- a/package.json
+++ b/package.json
@@ -30,19 +30,18 @@
   "@types/express": "^4.17.21",
   "@types/cors": "^2.8.14",
   "@types/helmet": "^4.0.0",
-  "@types/pino-http": "^6.0.6",
     "nodemon": "^3.1.10",
     "rimraf": "^5.0.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   },
   "dependencies": {
+  "dotenv": "^16.1.4",
     "dockerode": "^4.0.7",
     "express": "^5.1.0",
   "helmet": "^6.0.1",
   "cors": "^2.8.5",
   "express-rate-limit": "^7.0.0",
-  "pino-http": "^8.4.0",
     "get-port": "^7.1.0",
     "pino": "^8.21.0",
     "pino-pretty": "^8.1.0"

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,9 @@
 import express, { Express, Request, Response, NextFunction } from 'express';
+// Load environment variables from .env as early as possible so process.env values
+// (for example TRUST_PROXY) are available when Express initializes and when
+// middleware like express-rate-limit inspects req.ip / X-Forwarded-For.
+import dotenv from 'dotenv';
+dotenv.config();
 import helmet from 'helmet';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
@@ -34,16 +39,6 @@ app.use(
 		credentials: true,
 	})
 );
-
-// Detect ngrok browser-skip header for debugging convenience and log it.
-// This does not change behavior, only records when clients (like ngrok) send the header.
-app.use((req: Request, _res: Response, next: NextFunction) => {
-	const skipWarning = req.headers['ngrok-skip-browser-warning'];
-	if (skipWarning) {
-		logger.info({ header: skipWarning }, '🔄 ngrok-skip-browser-warning header detected');
-	}
-	next();
-});
 
 // Body parsing with size limit to mitigate large payload attacks
 app.use(express.json({ limit: '10kb' }));


### PR DESCRIPTION
This pull request updates environment variable handling and improves Express server configuration for production deployments and proxy support. The most important changes include switching the default environment to production, loading environment variables early using `dotenv`, and configuring Express to trust proxy headers when appropriate.

**Environment & Configuration Improvements:**

* Changed default `NODE_ENV` in `.env.example` to `production` and added `TRUST_PROXY=true` to clarify production settings.
* Added `dotenv` to dependencies in `package.json` and removed unused `@types/pino-http` and `pino-http` packages.
* Loaded environment variables at the top of `src/server.ts` using `dotenv.config()` to ensure settings like `TRUST_PROXY` are available before Express initialization.

**Proxy & Security Configuration:**

* Added logic in `src/server.ts` to set Express's `trust proxy` option based on `TRUST_PROXY` or `NODE_ENV`, improving client IP detection and security when behind a proxy or load balancer.