### PR TITLE
fix: add GitHub webhook testing and enhance encryption method

### DIFF
--- a/simple-test.js
+++ b/simple-test.js
@@ -1,0 +1,43 @@
+const crypto = require('crypto');
+
+async function testWebhook() {
+    const samplePayload = {
+        action: 'opened',
+        pull_request: { number: 123 }
+    };
+    
+    const secret = '4C9B740C59D8E6E33B840B0C55BF8DB1CF79152F4FEB088247665F2008F9CFAB';
+    const hmac = crypto.createHmac('sha256', secret);
+    hmac.update(JSON.stringify(samplePayload));
+    const signature = `sha256=${hmac.digest('hex')}`;
+    
+    console.log('Testing webhook...');
+    console.log('Signature:', signature);
+    
+    try {
+        const response = await fetch('http://localhost:3000/webhooks/github', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-GitHub-Event': 'pull_request',
+                'X-Hub-Signature-256': signature,
+                'User-Agent': 'GitHub-Hookshot/test'
+            },
+            body: JSON.stringify(samplePayload)
+        });
+        
+        const result = await response.text();
+        console.log('Status:', response.status);
+        console.log('Response:', result);
+        
+        if (response.ok) {
+            console.log('✅ SUCCESS: Webhook works!');
+        } else {
+            console.log('❌ FAILED: Webhook error');
+        }
+    } catch (error) {
+        console.error('Error:', error.message);
+    }
+}
+
+testWebhook();

--- a/src/middlewares/dispatcherServer.ts
+++ b/src/middlewares/dispatcherServer.ts
@@ -20,7 +20,10 @@ const deployments = new Map<number, DeploymentInfo>();
 function encryptData(data: string, key: string): EncryptedData {
   const algorithm = 'aes-256-gcm';
   const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipher(algorithm, key);
+  
+  // Create a 32-byte key from the provided key string
+  const keyBuffer = crypto.scryptSync(key, 'salt', 32);
+  const cipher = crypto.createCipheriv(algorithm, keyBuffer, iv);
   
   let encrypted = cipher.update(data, 'utf8', 'hex');
   encrypted += cipher.final('hex');
@@ -39,7 +42,10 @@ function encryptData(data: string, key: string): EncryptedData {
  */
 function decryptData(encryptedData: string, key: string, iv: string, tag: string): string {
   const algorithm = 'aes-256-gcm';
-  const decipher = crypto.createDecipher(algorithm, key);
+  
+  // Create a 32-byte key from the provided key string (same method as encryption)
+  const keyBuffer = crypto.scryptSync(key, 'salt', 32);
+  const decipher = crypto.createDecipheriv(algorithm, keyBuffer, Buffer.from(iv, 'hex'));
   
   decipher.setAuthTag(Buffer.from(tag, 'hex'));
   

--- a/src/server.ts
+++ b/src/server.ts
@@ -147,11 +147,10 @@ app.post('/admin/cleanup', (req: Request, res: Response) => {
 // Main GitHub webhook endpoint - now uses the comprehensive event dispatcher
 app.post(
 	'/webhooks/github',
-feat/verify-signature
-	verifySignature,
-	dispatchWebhookEvent
 	// Allow slightly larger payloads for webhooks while keeping global limit small
 	express.json({ limit: '100kb' }),
+	verifySignature,
+	dispatchWebhookEvent,
 	(req: Request, res: Response) => {
 		logger.info({ topic: 'webhook', provider: 'github' }, '📦 Received GitHub Webhook Payload');
 		// Also print the full payload to the terminal for debugging
@@ -161,7 +160,6 @@ feat/verify-signature
 		}
 		res.status(200).send('Webhook received');
 	}
-develop
 );
 
 // 404 handler


### PR DESCRIPTION
This pull request introduces improvements to webhook handling and cryptography in the codebase, focusing on secure encryption/decryption and testing the GitHub webhook integration. The most significant changes include switching to secure key derivation for AES encryption, updating the webhook endpoint middleware order, and adding a simple script to test webhook functionality.

**Cryptography improvements:**

* Updated the `encryptData` and `decryptData` functions in `src/middlewares/dispatcherServer.ts` to use `crypto.scryptSync` for deriving a secure 32-byte key from the provided key string, and switched to `crypto.createCipheriv`/`crypto.createDecipheriv` for AES-256-GCM encryption and decryption. This enhances cryptographic security by using proper key derivation and initialization vector handling. [[1]](diffhunk://#diff-c1bc0e4ae91be9c51b2a86d13c3bd842b5c95dac264dbb0a9f7e1cb98ad91de1L23-R26) [[2]](diffhunk://#diff-c1bc0e4ae91be9c51b2a86d13c3bd842b5c95dac264dbb0a9f7e1cb98ad91de1L42-R48)

**Webhook integration and testing:**

* Added a new script `simple-test.js` that generates a valid HMAC signature for a sample GitHub webhook payload and sends it to the local webhook endpoint, allowing for easy manual verification of the webhook handling logic.
* Fixed the middleware order for the `/webhooks/github` endpoint in `src/server.ts` to ensure `verifySignature` and `dispatchWebhookEvent` are called before the request handler, restoring proper signature verification and event dispatching.
* Removed an outdated or misplaced identifier (`develop`) from the webhook endpoint definition in `src/server.ts` for clarity and correctness.